### PR TITLE
2D advection of cellular automata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,7 @@ branches:
   only:
     - ufs_public_release
     - release/public-v1
-    - release/public-v2
-    - release/public-v2
     - release/ufs-v1.1.0
-    - master
 
 # Environment variables
 env:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,7 +3,7 @@ Copyright 2020 The Regents of the University of Colorado
 The stochastic_physics code incorporated in the Unified Forecast System (UFS) 
 was jointly developed by the National Oceanic and Atmospheric Administration and the 
 University of Colorado, Boulder. The gold standard copy of the Code 
-will be maintained by NOAA at https://github.com/noaa-psl/stochastic_physics.
+will be maintained by NOAA at https://github.com/noaa-psd/stochastic_physics.
  
 In cooperation with the Copyright Holder, the National Oceanic and 
 Atmospheric Administration is releasing this code under the 

--- a/cellular_automata_global.F90
+++ b/cellular_automata_global.F90
@@ -16,7 +16,7 @@ use update_ca,         only: update_cells_global,define_ca_domain
 use halo_exchange,     only: atmosphere_scalar_field_halo
 use random_numbers,    only: random_01_CB
 use mpp_domains_mod,   only: domain2D,mpp_get_global_domain,CENTER, mpp_get_data_domain, mpp_get_compute_domain,mpp_global_sum, &
-                             BITWISE_EFP_SUM, BITWISE_EXACT_SUM
+                             BITWISE_EFP_SUM, BITWISE_EXACT_SUM,mpp_define_io_domain,mpp_get_io_domain_layout
 use block_control_mod, only: block_control_type, define_blocks_packed
 use mpi_wrapper,       only: mp_reduce_sum,mp_reduce_max,mp_reduce_min, &
                              mpi_wrapper_initialize,mype,is_rootpe
@@ -50,6 +50,7 @@ integer :: nxncells, nyncells
 integer(8) :: count, count_rate, count_max, count_trunc,nx_full
 integer(8) :: iscale = 10000000000
 integer, allocatable :: iini_g(:,:,:),ilives_g(:,:)
+integer, allocatable :: io_layout(:)
 real(kind=kind_phys), allocatable :: field_out(:,:,:), field_smooth(:,:)
 real(kind=kind_phys), allocatable :: CA(:,:),CA1(:,:),CA2(:,:),CA3(:,:),CAprime(:,:)
 real*8              , allocatable :: noise(:,:,:)
@@ -73,7 +74,7 @@ if (first_time_step) then
    call mpi_wrapper_initialize(mpiroot,mpicomm)
 end if
 
-halo=1
+halo=3
 k_in=1
 
 !----------------------------------------------------------------------------
@@ -102,8 +103,12 @@ k_in=1
  !Get CA domain
 
  if(first_time_step)then 
-!    if (.not. restart) call define_ca_domain(domain_in,domain_global,ncells,nxncells_g,nyncells_g)
-     domain_global=domain_in
+    if (.not. restart) then
+       allocate(io_layout(2))
+       io_layout=mpp_get_io_domain_layout(domain_in)
+       call define_ca_domain(domain_in,domain_global,halo,ncells,nxncells_g,nyncells_g)
+       call mpp_define_io_domain(domain_global, io_layout)
+     endif
     call mpp_get_data_domain    (domain_global,isdnx_g,iednx_g,jsdnx_g,jednx_g)
     call mpp_get_compute_domain (domain_global,iscnx_g,iecnx_g,jscnx_g,jecnx_g)
  endif
@@ -203,7 +208,7 @@ k_in=1
 
     CA(:,:)=0.
 
-    call update_cells_global(kstep,first_time_step,iseed_ca,restart,nca,nxc,nyc,nxch,nych,nlon,nlat,isc,iec,jsc,jec, &
+    call update_cells_global(kstep,halo,first_time_step,iseed_ca,restart,nca,nxc,nyc,nxch,nych,nlon,nlat,isc,iec,jsc,jec, &
                             npx,npy,CA,iini_g,ilives_g,         &
                             nlives,ncells,nfracseed,nseed,nspinup,nf,mytile)
 

--- a/cellular_automata_sgs.F90
+++ b/cellular_automata_sgs.F90
@@ -6,10 +6,10 @@ implicit none
 
 contains
 
-subroutine cellular_automata_sgs(kstep,dtf,restart,first_time_step,sst,lsmsk,lake,condition_cpl, &
+subroutine cellular_automata_sgs(kstep,dtf,restart,first_time_step,sst,lsmsk,lake,uwind,vwind,height,dx,condition_cpl, &
             ca_deep_cpl,ca_turb_cpl,ca_shal_cpl,domain_in, &
             nblks,isc,iec,jsc,jec,npx,npy,nlev,nthresh, mytile, &
-            nca,ncells,nlives,nfracseed,nseed,iseed_ca, &
+            nca,ncells,nlives,nfracseed,nseed,iseed_ca,ca_advect, &
             nspinup,ca_trigger,blocksize,mpiroot,mpicomm)
 
 use kinddef,           only: kind_phys,kind_dbl_prec
@@ -37,6 +37,9 @@ implicit none
 ! swtich to new random number generator and improve computational efficiency
 ! and remove unsued code
 
+!L.Bengtsson, 2023-05
+!Add horizontal advection of CA cells
+
 !This routine produces an output field CA_DEEP for coupling to convection (saSAS).
 !CA_DEEP can be either number of plumes in a cluster (nca_plumes=true) or updraft 
 !area fraction (nca_plumes=false)
@@ -44,9 +47,9 @@ implicit none
 integer,intent(in) :: kstep,ncells,nca,nlives,nseed,nspinup,mpiroot,mpicomm,mytile
 integer(kind=kind_dbl_prec),           intent(in)    :: iseed_ca
 real(kind=kind_phys), intent(in)    :: nfracseed,dtf,nthresh
-logical,intent(in) :: restart,ca_trigger,first_time_step
+logical,intent(in) :: restart,ca_trigger,first_time_step,ca_advect
 integer, intent(in) :: nblks,isc,iec,jsc,jec,npx,npy,nlev,blocksize
-real(kind=kind_phys), intent(in)    :: sst(:,:),lsmsk(:,:),lake(:,:)
+real(kind=kind_phys), intent(in)    :: sst(:,:),lsmsk(:,:),lake(:,:),uwind(:,:,:),dx(:,:),vwind(:,:,:),height(:,:,:)
 real(kind=kind_phys), intent(inout) :: condition_cpl(:,:)
 real(kind=kind_phys), intent(inout) :: ca_deep_cpl(:,:)
 real(kind=kind_phys), intent(inout) :: ca_turb_cpl(:,:)
@@ -58,21 +61,22 @@ integer :: nlon, nlat, isize,jsize,nf,nn
 integer :: inci, incj, nxc, nyc, nxch, nych, nx, ny
 integer :: halo, k_in, i, j, k
 integer :: seed, ierr7,blk, ix, iix, count4,ih,jh
-integer :: blocksz,levs
+integer :: blocksz,levs,u200,u850
 integer, save :: initialize_ca
 integer(8) :: count, count_rate, count_max, count_trunc,nx_full
 integer(8) :: iscale = 10000000000
 integer, allocatable :: iini(:,:,:),ilives_in(:,:,:),ca_plumes(:,:),io_layout(:)
-real(kind=kind_phys), allocatable :: ssti(:,:),lsmski(:,:),lakei(:,:)
-real(kind=kind_phys), allocatable :: CA(:,:),condition(:,:),conditiongrid(:,:)
-real(kind=kind_phys), allocatable :: CA_DEEP(:,:)
+real(kind=kind_phys), allocatable :: ssti(:,:),lsmski(:,:),lakei(:,:),uwindi(:,:),vwindi(:,:),dxi(:,:),heighti(:,:,:)
+real(kind=kind_phys), allocatable :: CA(:,:),condition(:,:),uhigh(:,:),vhigh(:,:),dxhigh(:,:),conditiongrid(:,:)
+real(kind=kind_phys), allocatable :: CA_DEEP(:,:),zi(:,:,:),sumx(:,:)
 real*8              , allocatable :: noise(:,:,:)
-real(kind=kind_phys) :: condmax,condmaxinv,livesmax,livesmaxinv,factor,dx,pi,re
+real(kind=kind_phys) :: condmax,condmaxinv,livesmax,livesmaxinv,factor,pi,re
 logical,save         :: block_message=.true.
 logical              :: nca_plumes
 logical,save         :: first_flag
 integer*8            :: i1,j1
 integer              :: ct
+real                 :: dz,grav
 
 !nca         :: switch for number of cellular automata to be used.
 !            :: for the moment only 1 CA can be used 
@@ -88,8 +92,13 @@ if (first_time_step) then
    call mpi_wrapper_initialize(mpiroot,mpicomm)
 end if
 
-halo=1
+halo=3
 k_in=1
+!Right now these values are experimental:                                                                                                                                                                                     
+u200=56
+u850=13
+!Gravitational acceleration: 
+grav=9.81
 
 nca_plumes = .true.
 
@@ -132,15 +141,12 @@ endif
   if (.not.restart) then
       allocate(io_layout(2))
       io_layout=mpp_get_io_domain_layout(domain_in)
-      call define_ca_domain(domain_in,domain_sgs,ncells,nxncells,nyncells)
+      call define_ca_domain(domain_in,domain_sgs,halo,ncells,nxncells,nyncells)
       call mpp_define_io_domain(domain_sgs, io_layout)
   endif
   call mpp_get_data_domain    (domain_sgs,isdnx,iednx,jsdnx,jednx)
   call mpp_get_compute_domain (domain_sgs,iscnx,iecnx,jscnx,jecnx)
-  !write(1000+mpp_pe(),*) "nxncells,nyncells: ",nxncells,nyncells
-  !write(1000+mpp_pe(),*) "iscnx,iecnx,jscnx,jecnx: ",iscnx,iecnx,jscnx,jecnx
-  !write(1000+mpp_pe(),*) "isdnx,iednx,jsdnx,jednx: ",isdnx,iednx,jsdnx,jednx
-endif
+ endif
 
   nxc = iecnx-iscnx+1
   nyc = jecnx-jscnx+1
@@ -152,9 +158,18 @@ endif
  allocate(ssti(nlon,nlat))
  allocate(lsmski(nlon,nlat))
  allocate(lakei(nlon,nlat))
+ allocate(uwindi(nlon,nlat))
+ allocate(vwindi(nlon,nlat))
+ allocate(heighti(nlon,nlat,nlev))
+ allocate(zi(nlon,nlat,nlev))
+ allocate(sumx(nlon,nlat))
+ allocate(dxi(nlon,nlat))
  allocate(iini(nxc,nyc,nca))
  allocate(ilives_in(nxc,nyc,nca))
  allocate(condition(nxc,nyc))
+ allocate(uhigh(nxc,nyc))
+ allocate(dxhigh(nxc,nyc))
+ allocate(vhigh(nxc,nyc))
  allocate(conditiongrid(nlon,nlat))
  allocate(CA(nlon,nlat))
  allocate(ca_plumes(nlon,nlat))
@@ -163,6 +178,9 @@ endif
  !Initialize:
  ilives_in(:,:,:) = 0
  iini(:,:,:) = 0
+ sumx(:,:) = 0.
+ uwindi(:,:) = 0.
+ vwindi(:,:) =0.
 
  !Put the blocks of model fields into a 2d array - can't use nlev and blocksize directly,
  !because the arguments to define_blocks_packed are intent(inout) and not intent(in).
@@ -172,6 +190,7 @@ endif
  call define_blocks_packed('cellular_automata', Atm_block, isc, iec, jsc, jec, levs, &
                               blocksz, block_message)
 
+
  do blk = 1,Atm_block%nblks
   do ix = 1, Atm_block%blksz(blk)
       i = Atm_block%index(blk)%ii(ix) - isc + 1
@@ -180,13 +199,39 @@ endif
       ssti(i,j)          = sst(blk,ix)
       lsmski(i,j)        = lsmsk(blk,ix)
       lakei(i,j)         = lake(blk,ix)
+      dxi(i,j)           = dx(blk,ix)
+      do k = 1,levs
+         heighti(i,j,k) = height(blk,ix,k)/grav
+      enddo
+      do k = 2,levs
+         zi(i,j,k)=0.5*(heighti(i,j,k)+heighti(i,j,k-1))
+      enddo
+      do k = u850,u200
+         dz=zi(i,j,k)-zi(i,j,k-1)
+         uwindi(i,j)   = uwindi(i,j) + uwind(blk,ix,k)*dz
+         vwindi(i,j)   = vwindi(i,j) + vwind(blk,ix,k)*dz
+         sumx(i,j) = sumx(i,j) + dz
+      enddo
   enddo
  enddo
+
+ do blk = 1,Atm_block%nblks
+  do ix = 1, Atm_block%blksz(blk)
+      i = Atm_block%index(blk)%ii(ix) - isc + 1
+      j = Atm_block%index(blk)%jj(ix) - jsc + 1
+      uwindi(i,j)=uwindi(i,j)/sumx(i,j)
+      vwindi(i,j)=vwindi(i,j)/sumx(i,j)
+   enddo
+ enddo
+         
 
 !Initialize the CA when the condition field is populated
   do j=1,nyc
    do i=1,nxc
      condition(i,j)=conditiongrid(inci/ncells,incj/ncells)
+     uhigh(i,j)=uwindi(inci/ncells,incj/ncells)
+     vhigh(i,j)=vwindi(inci/ncells,incj/ncells)
+     dxhigh(i,j)=dxi(inci/ncells,incj/ncells)/ncells !dx on the finer grid
      if(i.eq.inci)then
      inci=inci+ncells
      endif
@@ -277,9 +322,9 @@ endif !  cold_start_ca_sgs
 
 !Calculate neighbours and update the automata
  do nf=1,nca
-  call update_cells_sgs(kstep,initialize_ca,iseed_ca,first_flag,restart,first_time_step,nca,nxc,nyc, &
-                        nxch,nych,nlon,nlat,isc,iec,jsc,jec, &
-                        npx,npy,CA,ca_plumes,iini,ilives_in,        &
+  call update_cells_sgs(kstep,halo,dtf,initialize_ca,iseed_ca,first_flag,restart,first_time_step,nca,nxc,nyc, &
+                        nxch,nych,nlon,nlat,isc,iec,jsc,jec,ca_advect, &
+                        npx,npy,CA,ca_plumes,iini,ilives_in,uhigh,vhigh,dxhigh, &
                         nlives,nfracseed,nseed,nspinup,nf,nca_plumes,ncells,mytile)
 
     if(nca_plumes)then
@@ -328,6 +373,11 @@ enddo
  deallocate(lakei)
  deallocate(iini)
  deallocate(ilives_in)
+ deallocate(uwindi)
+ deallocate(vwindi)
+ deallocate(uhigh)
+ deallocate(vhigh)
+ deallocate(dxhigh)
  deallocate(condition)
  deallocate(CA)
  deallocate(ca_plumes)

--- a/cellular_automata_sgs.F90
+++ b/cellular_automata_sgs.F90
@@ -76,7 +76,7 @@ logical              :: nca_plumes
 logical,save         :: first_flag
 integer*8            :: i1,j1
 integer              :: ct
-real                 :: dz,grav
+real                 :: dz,invgrav
 
 !nca         :: switch for number of cellular automata to be used.
 !            :: for the moment only 1 CA can be used 
@@ -98,7 +98,7 @@ k_in=1
 u200=56
 u850=13
 !Gravitational acceleration: 
-grav=9.81
+invgrav=1./9.81
 
 nca_plumes = .true.
 
@@ -201,7 +201,7 @@ endif
       lakei(i,j)         = lake(blk,ix)
       dxi(i,j)           = dx(blk,ix)
       do k = 1,levs
-         heighti(i,j,k) = height(blk,ix,k)/grav
+         heighti(i,j,k) = height(blk,ix,k)*invgrav
       enddo
       do k = 2,levs
          zi(i,j,k)=0.5*(heighti(i,j,k)+heighti(i,j,k-1))

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -5,3 +5,6 @@ The stochastic physics currently only works with the UFS-atmosphere model
 You should get the full system at https://github.com/ufs-community/ufs-weather-model, which will include the stochastic physics code.
 
 In order to enable stochastic physics in a model run, you will need to turn it on via `namelist options <namelist_options.html>`_
+
+If using the CIME workflow decribed at https://ufs-mrweather-app.readthedocs.io/en/latest/, please add do_sppt=T, etc. to user_nl_ufsatm in the case directory.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,5 +14,5 @@ Welcome to UFS stochastic physics's documentation!
 Source Code Documentation
 ==========================
 
-#Doxygen generated (out of date) `content <https://noaa-psd.github.io/stochastic_physics/doxygen/index.html>`_
+Doxygen generated `content <https://noaa-psd.github.io/stochastic_physics/doxygen/index.html>`_
 

--- a/docs/source/namelist_options.rst
+++ b/docs/source/namelist_options.rst
@@ -8,11 +8,11 @@ General options
    :header: "Option", "Description"
    :widths: 30, 50
 
-   "NEW_LSCALE", "Recommended, set to true if use the correct calculation for decorrelation length scale."
    "NTRUNC", "Optional, Spectral resolution (e.g. T126) of random patterns, default is for model to determine proper truncation"
    "LAT_S", "Optional, number of latitude points for the gaussian grid  (must be even), default is for model to determine gaussian grid"
    "LON_S", "Optional, number of longitude points for the gaussian grid (recommend 2xLAT_S, default is for model to determine gaussian grid"
-   "STOCHINI", "Optional, set to true if wanting to read in a previous random pattern"
+   "FHSTOCH", "Optional, forecast hour to write out random pattern in order to restart the pattern for a different forecast (used in DA), file is stoch_out.F<HHH>"
+   "STOCHINI", "Optional, set to true if wanting to read in a previous random pattern (input file needs to be named stoch_ini)."
 
 SPPT options 
 """"""""""""
@@ -21,31 +21,31 @@ SPPT options
    :header: "Option", "Description"
    :widths: 30, 50
 
-   "SPPT", "Amplitudes of random patterns."
-   "SPPT_TAU", "Decorrelation timescales in seconds."
-   "SPPT_LSCALE", "Decorrelation spatial scales in meters."
+   "DO_SPPT", "logical to tell parent atmospheric model to use SPPT"
+   "SPPT", "Amplitudes of random patterns (0.8,0.4,0.2,0.08,0.04) *"
+   "SPPT_TAU", "Decorrelation timescales in seconds (21600,1.728E5,6.912E5,7.776E6,3.1536E7) *"
+   "SPPT_LSCALE", "Decorrelation spatial scales in meters  (250.E3,1000.E3,2000.E3,2000.E3,2000.E3) *"
    "SPPT_LOGIT", "Should be true to limit the SPPT perturbations between 0 and 2.  Otherwise model will crash."
    "ISEED_SPPT", "Seeds for setting the random number sequence (ignored if stochini is true)"
    "SPPT_SIGTOP1", "lower sigma level to taper perturbations to zero (default is 0.1)"
-   "SPPT_SIGTOP2", "upper sigma level to taper perturbations to zero (default is 0.025)"
+   "SPPT_SIGTOP2", "upper sigma level to taper perturbations to zero (0.025)"
    "SPPT_SFCLIMIT", ".T.=tapers the SPPT perturbations to zero at model’s lowest level (helps reduce model crashes)"
    "SPPTINT", "Optional, interval in seconds to update random pattern.  Perturbations still get applied every time-step"
    "USE_ZMTNBLCK", ".T.=do not apply perturbations below the dividing streamline that is diagnosed by the gravity wave drag, mountain blocking scheme"
-   "PERT_MP", ".T.=apply SPPT perturbations to all microphysics specis. If .F. the SPPT is only applied to u,v,t,qv"
-   "PERT_RADTEND", ".T.=apply SPPT perturbations to cloudy sky radiation tendencies. If .F. then do not perturb any radiative tendencies"
-   "PERT_CLDS", ".T.=apply SPPT perturbations to fraction (only works for RRTMG radiation),  if using this option set PERT_RADTEND=.F."
 
+``*``  **SPPT** uses 5 different patterns of varying time/length scales that are added together before being passed to physics
 
 SHUM options 
 """"""""""""
 
 .. csv-table::
    :header: "Option", "Description"
-   :widths: 30, 50
+   :widths: 20, 50
 
-   "SHUM", "Amplitudes of random pattern."
-   "SHUM_TAU", "Decorrelation timescales in seconds."
-   "SHUM_LSCALE", "ecorrelation spatial scales in meters."
+   "DO_SHUM", "logical to tell parent atmospheric model to use SHUM"
+   "SHUM", "Amplitudes of random patterns (0.004)"
+   "SHUM_TAU", "Decorrelation timescales in seconds (21600)"
+   "SHUM_LSCALE", "ecorrelation spatial scales in meters (250000)"
    "SHUM_SIGEFOLD", "e-folding lengthscale (in units of sigma) of specific humidity perturbations, default is 0.2)"
    "SHUMINT", "Optional, interval in seconds to update random pattern.  Perturbations still get applied every time-step"
    "ISEED_SHUM", "Seeds for setting the random number sequence (ignored if stochini is true)."
@@ -57,8 +57,9 @@ SKEB options
    :header: "Option", "Description"
    :widths: 30, 50
 
-   "SKEB", "Amplitudes of random patterns."
-   "SKEB_TAU", "Decorrelation timescales in seconds"
+   "DO_SKEB", "logical to tell parent atmospheric model to use SKEB"
+   "SKEB", "Amplitudes of random patterns (0.5)"
+   "SKEB_TAU", "Decorrelation timescales in seconds (21600)"
    "SKEB_LSCALE", "Decorrelation spatial scales in meters  (250)"
    "ISEED_SKEB", "Seeds for setting the random number sequence (ignored if stochini is true)."
    "SKEBNORM", "0-random pattern is stream function, 1-pattern is K.E. norm, 2-pattern is vorticity (default is 0)"
@@ -68,35 +69,4 @@ SKEB options
    "SKEB_SIGTOP1", "lower sigma level to taper perturbations to zero (default is 0.1)"
    "SKEB_SIGTOP2", "upper sigma level to taper perturbations to zero (0.025)"
    "SKEBINT", "Optional, interval in seconds to update random pattern.  Perturbations still get applied every time-step"
-
-SPP options
-""""""""""""
-
-.. csv-table::
-   :header: "Option", "Description"
-   :widths: 30, 50
-
-   "SPP_VAR_LIST", "List of parameterizations to be perturbed. Check compns_stochy.F90 for options."
-   "SPP_PRT_LIST", "SPP perturbation magnitudes used in each parameterization."
-   "SPP_TAU", "Decorrelation timescales in seconds."
-   "SPP_LSCALE", "Decorrelation spatial scales in meters."
-   "ISEED_SPP", "Seeds for setting the random number sequence (ignored if stochini is true)."
-   "SPP_SIGTOP1", "Lower sigma level to taper perturbations to zero (default is 0.1)"
-   "SPP_SIGTOP2", "Upper sigma level to taper perturbations to zero (0.025)"
-   "SPP_STDDEV_CUTOFF", "Limit for possible perturbation values in standard deviations from the mean."
-
-
-Land perturbation options
-""""""""""""
-
-.. csv-table::
-   :header: "Option", "Description"
-   :widths: 30, 50
-
-   "LNDP_TYPE", "0, no perturbations. 1, old scheme (Gehne et al. 2019); 2, new scheme (Draper 2021)"
-   "LNDP_VAR_LIST", "List of land perturbations parameters. Check compns_stochy.F90 for options"
-   "LNDP_PRT_LIST", "Perturbation magnitudes used for each parameter perturbations."
-   "LNDP_TAU", "Decorrelation timescales in seconds."
-   "LNDP_LSCALE", "Decorrelation spatial scales in meters."
-   "ISEED_LNDP", "Seeds for setting the random number sequence (ignored if stochini is true)."
 

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -1,15 +1,13 @@
 References     
 ==========
 
-Bengtsson, L., J. Dias, M. Gehne, P. Bechtold, J. Whitaker, 2019: Convectively Coupled Equatorial Wave Simulations Using the ECMWF IFS and the NOAA GFS Cumulus Convection Schemes in the NOAA GFS Model. *Mon. Wea. Rev.* **147**, 4005 - 4025, `doi:10.1175/MWR-D-19-0195.1 <https://journals.ametsoc.org/view/journals/mwre/147/11/mwr-d-19-0195.1.xml>`_
+Berner, J., G. Shutts, M. Leutbecher, and T. Palmer, 2009: A spectral stochastic kinetic energy backscatter scheme and its impact on flow- dependent predictability in the ECMWF ensemble prediction system. J. Atmos. Sci., 66, 603–626, `doi:10.1175/2008JAS2677.1 <https://journals.ametsoc.org/doi/full/10.1175/2008JAS2677.1>`_
 
-Berner, J., G. Shutts, M. Leutbecher, and T. Palmer, 2009: A spectral stochastic kinetic energy backscatter scheme and its impact on flow- dependent predictability in the ECMWF ensemble prediction system. *J. Atmos. Sci.,* **66**, 603–626, `doi:10.1175/2008JAS2677.1 <https://journals.ametsoc.org/doi/full/10.1175/2008JAS2677.1>`_
+Draper, C, 2021: Accounting for Land Model Uncertainty in Numerical Weather Prediction Ensemble Systems: Toward Ensemble-Based Coupled Land–Atmosphere Data Assimilation, J Hydromet, 22(8), 2089-2104, `<https://journals.ametsoc.org/view/journals/hydr/22/8/JHM-D-21-0016.1.xml>`_
 
-Draper, C., 2021: Accounting for Land Model Uncertainty in Numerical Weather Prediction Ensemble Systems: Toward Ensemble-Based Coupled Land–Atmosphere Data Assimilation. *J. Hydromet.,* **22**, 2089–2104,  `doi:10.1175/JHM-D-21.0016.1 <https://doi.org/10.1175/JHM-D-21-0016.1>`_
 
-Gehne, M., T. Hamill, G. Bates, P. Pegion, W. Kolczynski 2019: Land-surface parameter and state perturbations in the Global Ensemble Forecast System. *Mon. Wea. Rev.* **147**, 1319–1340 `doi:10.1175/MWR-D-18-0057.1 <https://journals.ametsoc.org/doi/10.1175/MWR-D-18-0057.1>`_
+Palmer, T. N., R. Buizza, F. Doblas-Reyes, T. Jung, M. Leutbecher, G. J. Shutts,M. Steinheimer, and A.Weisheimer, 2009: Stochastic parametrization and model uncertainty. ECMWF Tech. Memo. 598, 42 pp `doi:10.21957/ps8gbwbdv <https://www.ecmwf.int/node/11577>`_
 
-Palmer, T. N., R. Buizza, F. Doblas-Reyes, T. Jung, M. Leutbecher, G. J. Shutts,M. Steinheimer, and A.Weisheimer, 2009: Stochastic parametrization and model uncertainty. *ECMWF Tech. Memo.* **598**, 42 pp `doi:10.21957/ps8gbwbdv <https://www.ecmwf.int/node/11577>`_
 
-Tompkins, A. M., and J. Berner, 2008: A stochastic convective approach to account for model uncertainty due to unresolved humidity variability. *J. Geophys. Res.,* **113**, D18101, `doi:10.1029/2007JD009284 <https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2007JD009284>`_
+Tompkins, A. M., and J. Berner, 2008: A stochastic convective approach to account for model uncertainty due to unresolved humidity variability. J. Geophys. Res., 113, D18101, `doi:10.1029/2007JD009284 <https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2007JD009284>`_
 

--- a/docs/source/users_guide.rst
+++ b/docs/source/users_guide.rst
@@ -2,7 +2,7 @@ Users Guide
 ==================================================
 The stochastic physics currently only works with the UFS-atmosphere model
 
-Currently, 3 stochastic schemes are used operationally at NCEP/EMC: Stochastic Kinetic Energy Backscatter (SKEB; Berner et al., 2009), Stochastically Perturbed Physics Tendencies (SPPT; Palmer et al., 2009), and Specific Humidity perturbations (SHUM), which is inspired by Tompkins and Berner, 2008. In addition there is the ability to perturb certain land model/surface parameters (Gehne et al., 2019 and Draper 2021), and a cellular automata scheme (Bengtsson et al. 2019) which interacts directly with the convective parameterization.
+Currently, 3 stochastic schemes are used operationally at NCEP/EMC: Stochastic Kinetic Energy Backscatter (SKEB; Berner et al., 2009), Stochastically Perturbed Physics Tendencies (SPPT; Palmer et al., 2009), and Specific Humidity perturbations (SHUM), which is inspired by Tompkins and Berner, 2008. In addition there is the ability to perturb certain land model/surface parameters (Draper, 2021), and a cellular automata scheme (Bengtsson et al. 2019) which interacts directly with the convective parameterization.
 
 SKEB adds wind perturbations to model state.  Perturbations are random in space/time, but amplitude is determined by a smoothed dissipation estimate provided by the dynamical core. 
 Addresses errors in the dynamics  - more active in the mid-latitudes
@@ -11,12 +11,9 @@ SPPT multiplies the physics tendencies by a random number O [0,2] before updatin
 
 SHUM multiply the low-level specific humidity by a small random number each time-step. It attempts to address missing physics (cold pools, gust fronts), most active in convective regions
 
-Land surface perturbations allow for land surface parameters such as Albedo, Soil Hydraulic Conductivity, LAI, and roughness lengths to vary in space. Addresses error in the land model and land-atmosphere interactions. The perturbation options are only available to NOAH and RUC-LSM land models.
+Land surface perturbations can be applied to the land model parameters and land model prognostic variables. The scheme is intended to address errors in the land model and land-atmosphere interactions.  
 
 Due to the model’s numerics, any stochastic perturbation needs to be correlated in space and time in order to have the desired effect of upscale growth of the perturbations. This is achieved by creating a random pattern that has a specified decorrelation length-scale and is a first order auto-regressive process AR(1) in time with a specified decorrelation time-scale.  (The CA random pattern generator also satisfies this condition)
 
-Cellular automata is enabled through the physics namelist
-
-
-Stochastic Paramter Perturbation (SPP) is avaiable for the FV3_HRRR physics suite
+Currently the Land surface perturbations and cellular automata are not supported at the workflow level.  
 

--- a/halo_exchange.fv3.F90
+++ b/halo_exchange.fv3.F90
@@ -75,8 +75,8 @@ contains
    if (halo == 1) then
      call mpp_update_domains(data, domain_for_coupler, flags=mpp_flags, complete=.true.)
    ! Not needed for cellular automata code
-   !elseif (halo == 3) then
-   !  call mpp_update_domains(data, Atm(mytile)%domain, flags=mpp_flags, complete=.true.)
+   elseif (halo == 3) then
+     call mpp_update_domains(data, domain_for_coupler, flags=mpp_flags, complete=.true.)
    else
      call mpp_error(FATAL, modname//' - unsupported halo size')
    endif


### PR DESCRIPTION
*Add namelist ca_advect as control switch.
*Ensure the same definition for halo sizes are used in the domain construction, as when allocating data to be used in the atmospehre_scalar_field_halo routines.
*Update halo size from 1 to 3.
*Bring in U,V and control flags from FV3 to CA driver routines - compute mean level wind
*2D advection of CA cells
