### PR TITLE
add SPP support to G-F deep convection

### DIFF
--- a/compns_stochy.F90
+++ b/compns_stochy.F90
@@ -82,7 +82,7 @@ module compns_stochy_mod
       skeb             = -999.  ! stochastic KE backscatter amplitude
       lndp_var_list  = 'XXX'
       lndp_prt_list  = -999.
-      spp_var_list  = 'XXX'
+      spp_var_list  = 'XXXXXXXXXX'
       spp_prt_list  = -999.
 ! logicals
       do_sppt = .false.
@@ -345,7 +345,7 @@ module compns_stochy_mod
      ! count requested pert variables
      n_var_spp= 0
      do k =1,size(spp_var_list)
-         if  ( (spp_var_list(k) .EQ. 'XXX') .or. (spp_prt_list(k) .LE. 0.) ) then
+         if  ( (spp_var_list(k) .EQ. 'XXXXXXXXXX') .or. (spp_prt_list(k) .LE. 0.) ) then
             cycle
          else
              n_var_spp=n_var_spp+1
@@ -366,7 +366,7 @@ module compns_stochy_mod
          'SPP physics perturbations will be applied to selected parameters', n_var_spp
         do k =1,n_var_spp
             select case (spp_var_list(k))
-            case('pbl','sfc', 'mp','rad','gwd')
+            case('pbl','sfc', 'mp','rad','gwd','cu_deep')
                 if (me==0) print*, 'SPP physics perturbation will be applied to ', spp_var_list(k)
             case default
                print*, 'ERROR: SPP physics perturbation requested for new parameter - will need to be coded in spp_apply_pert', spp_var_list(k)

--- a/stochastic_physics.F90
+++ b/stochastic_physics.F90
@@ -56,7 +56,7 @@ logical,                  intent(out)   :: use_zmtnblck_out
 integer,                  intent(out)   :: skeb_npass_out
 character(len=3),         dimension(:), intent(out) :: lndp_var_list_out
 real(kind=kind_phys), dimension(:), intent(out) :: lndp_prt_list_out
-character(len=3),         dimension(:), intent(out) :: spp_var_list_out
+character(len=10),         dimension(:), intent(out) :: spp_var_list_out
 real(kind=kind_phys), dimension(:), intent(out) :: spp_prt_list_out
 real(kind=kind_phys), dimension(:), intent(out) :: spp_stddev_cutoff_out
 

--- a/stochy_data_mod.F90
+++ b/stochy_data_mod.F90
@@ -57,7 +57,7 @@ module stochy_data_mod
    character(len=64), intent(in) :: fn_nml
    real(kind_phys), intent(in) :: delt
    integer, intent(out) :: iret
-   real :: ones(5)
+   real :: ones(6)
 
    real :: rnn1
    integer :: nn,k,nm,stochlun,ierr,n

--- a/stochy_namelist_def.F90
+++ b/stochy_namelist_def.F90
@@ -46,7 +46,7 @@
      &                                        , spp_sigtop1, spp_sigtop2
       integer n_var_spp
       integer(8),dimension(max_n_var_spp) ::iseed_spp
-      character(len=3), dimension(max_n_var_spp)         ::  spp_var_list
+      character(len=10), dimension(max_n_var_spp)         ::  spp_var_list
       real(kind=kind_phys), dimension(max_n_var_spp) ::  spp_prt_list
 
       end module stochy_namelist_def


### PR DESCRIPTION
This PR is co-authored with Georg Grell and @haiqinli to add stochastic parameterization perturbations support to Grell-Freitas deep convection parameterization by passing stochastic patterns to mass transport, vertical mass flux profile and closures

Related PRs:

ccpp-physics:
https://github.com/ufs-community/ccpp-physics/pull/98

fv3atm:
https://github.com/NOAA-EMC/fv3atm/pull/688

