### PR TITLE
Adding pbl_taper to namelist to define PBL tapering profile

### DIFF
--- a/compns_stochy.F90
+++ b/compns_stochy.F90
@@ -62,7 +62,7 @@ module compns_stochy_mod
       skeb_sigtop1,skeb_sigtop2,skebnorm,sppt_sigtop1,sppt_sigtop2,&
       shum_sigefold,spptint,shumint,skebint,skeb_npass,use_zmtnblck,new_lscale, &
       epbl,epbl_lscale,epbl_tau,iseed_epbl,                                    &
-      ocnsppt,ocnsppt_lscale,ocnsppt_tau,iseed_ocnsppt
+      ocnsppt,ocnsppt_lscale,ocnsppt_tau,iseed_ocnsppt,pbl_taper
       namelist /nam_sfcperts/lndp_type,lndp_model_type, lndp_var_list, lndp_prt_list, & 
                             iseed_lndp, lndp_tau,lndp_lscale 
 !     For SPP physics parameterization perterbations
@@ -144,6 +144,7 @@ module compns_stochy_mod
       spp_sigtop2 = 0.025
 ! reduce amplitude of sppt near surface (lowest 2 levels)
       sppt_sfclimit = .false.
+      pbl_taper = (/0.0,0.5,1.0,1.0,1.0,1.0,1.0/)
 ! gaussian or power law variance spectrum for skeb (0: gaussian, 1:
 ! power law). If power law, skeb_lscale interpreted as a power not a
 ! length scale.
@@ -444,7 +445,7 @@ module compns_stochy_mod
       skeb_sigtop1,skeb_sigtop2,skebnorm,sppt_sigtop1,sppt_sigtop2,&
       shum_sigefold,spptint,shumint,skebint,skeb_npass,use_zmtnblck,new_lscale, &
       epbl,epbl_lscale,epbl_tau,iseed_epbl,                                    &
-      ocnsppt,ocnsppt_lscale,ocnsppt_tau,iseed_ocnsppt
+      ocnsppt,ocnsppt_lscale,ocnsppt_tau,iseed_ocnsppt,pbl_taper
 
       namelist /nam_sfcperts/lndp_type,lndp_model_type,lndp_var_list, lndp_prt_list, iseed_lndp, & 
       lndp_tau,lndp_lscale 

--- a/stochastic_physics.F90
+++ b/stochastic_physics.F90
@@ -162,8 +162,9 @@ if (do_sppt) then
       endif
    enddo
    if (sppt_sfclimit) then
-       vfact_sppt(2)=vfact_sppt(3)*0.5
-       vfact_sppt(1)=0.0
+       do k=1,7
+       vfact_sppt(k)=pbl_taper(k)
+       enddo
    endif
    if (is_rootpe()) then
       do k=1,levs

--- a/stochy_namelist_def.F90
+++ b/stochy_namelist_def.F90
@@ -27,6 +27,7 @@
       real(kind=kind_phys), dimension(5) :: shum,shum_lscale,shum_tau
       real(kind=kind_phys), dimension(5) :: epbl,epbl_lscale,epbl_tau
       real(kind=kind_phys), dimension(5) :: ocnsppt,ocnsppt_lscale,ocnsppt_tau
+      real(kind=kind_phys), dimension(7) :: pbl_taper
       integer,dimension(5) ::skeb_vfilt
       integer(kind=8),dimension(5) ::iseed_sppt,iseed_shum,iseed_skeb,iseed_epbl,iseed_ocnsppt,iseed_epbl2
       logical stochini,sppt_logit,new_lscale


### PR DESCRIPTION
This PR is to address [issue#64 ](https://github.com/NOAA-PSL/stochastic_physics/issues/64) to add a parameter (pbl_taper) to define a tapering profile for SPPT in order to prevent model from occasional crash. 