### PR TITLE
Add ability to run cellular automata in RRFS

### DIFF
--- a/cellular_automata_sgs.F90
+++ b/cellular_automata_sgs.F90
@@ -16,7 +16,7 @@ use kinddef,           only: kind_phys,kind_dbl_prec
 use update_ca,         only: update_cells_sgs, define_ca_domain
 use random_numbers,    only: random_01_CB
 use mpp_domains_mod,   only: domain2D,mpp_get_global_domain,CENTER, mpp_get_data_domain, mpp_get_compute_domain,&
-                             mpp_define_io_domain,mpp_get_io_domain_layout
+                             mpp_define_io_domain,mpp_get_io_domain_layout,mpp_get_ntile_count
 use block_control_mod, only: block_control_type, define_blocks_packed
 use time_manager_mod, only: time_type
 use mpi_wrapper,       only: mype,mp_reduce_max, &
@@ -75,7 +75,7 @@ logical,save         :: block_message=.true.
 logical              :: nca_plumes
 logical,save         :: first_flag
 integer*8            :: i1,j1
-integer              :: ct
+integer              :: ct,ntiles
 real                 :: dz,invgrav
 
 !nca         :: switch for number of cellular automata to be used.
@@ -124,7 +124,8 @@ endif
 
  !Set time and length scales:
  call mpp_get_global_domain(domain_in,xsize=nx,ysize=ny,position=CENTER)
- 
+ ntiles = mpp_get_ntile_count(domain_in)
+
  if(mype == 1)then
  write(*,*)'ncells=',ncells
  write(*,*)'nlives=',nlives
@@ -348,6 +349,7 @@ endif !  cold_start_ca_sgs
 
 !Limit CA activity to the Tropical Ocean
 
+if(ntiles==6)then 
 do j=1,nlat
    do i=1,nlon
       if(ssti(i,j) < 300. .or. lsmski(i,j) /= 0. .or. lakei(i,j) > 0.0)then
@@ -355,6 +357,7 @@ do j=1,nlat
       endif
    enddo
 enddo
+endif
 
 !Put back into blocks 1D array to be passed to physics
 !or diagnostics output


### PR DESCRIPTION
Add possibility to run the CA on a single tile by adding a cubed-sphere, single face tile with no contact surfaces in the CA domain specification.
Ensure decomposition of domain is proportional between the atmosphere domain and the higher resolution CA domain. 

This PR addresses the issue: https://github.com/ufs-community/ufs-weather-model/issues/1898

No changes to baselines are expected. 