### PR TITLE
Add the stochastic pattern interval option to SPP and LNDP

### DIFF
--- a/compns_stochy.F90
+++ b/compns_stochy.F90
@@ -156,7 +156,7 @@ module compns_stochy_mod
       spp_tau     = -999.       ! time scales
       spp_stddev_cutoff = 0     ! cutoff/limit for std-dev (zero==no limit applied)
       iseed_spp   = 0           ! random seeds (if 0 use system clock)
-      sppint      = 0           ! SPP time step interval
+      sppint      = 0           ! SPP interval in seconds
 
 #ifdef INTERNAL_FILE_NML
       read(input_nml_file, nml=nam_stochy)

--- a/compns_stochy.F90
+++ b/compns_stochy.F90
@@ -67,7 +67,7 @@ module compns_stochy_mod
                             iseed_lndp, lndp_tau,lndp_lscale 
 !     For SPP physics parameterization perterbations
       namelist /nam_sppperts/spp_var_list, spp_prt_list, iseed_spp, &
-      spp_tau,spp_lscale,spp_sigtop1, spp_sigtop2,spp_stddev_cutoff
+      sppint,spp_tau,spp_lscale,spp_sigtop1,spp_sigtop2,spp_stddev_cutoff
 
       rerth  =6.3712e+6      ! radius of earth (m)
       tol=0.01  ! tolerance for calculations
@@ -156,6 +156,7 @@ module compns_stochy_mod
       spp_tau     = -999.       ! time scales
       spp_stddev_cutoff = 0     ! cutoff/limit for std-dev (zero==no limit applied)
       iseed_spp   = 0           ! random seeds (if 0 use system clock)
+      sppint      = 0           ! SPP time step interval
 
 #ifdef INTERNAL_FILE_NML
       read(input_nml_file, nml=nam_stochy)
@@ -212,6 +213,9 @@ module compns_stochy_mod
             skeb=skeb*1.111e-9*sqrt(deltim)
          endif
       ENDIF
+      IF (spp_prt_list(1) > 0 ) THEN
+         do_spp=.true.
+      ENDIF
 !    compute frequencty to estimate dissipation timescale
       IF (do_skeb) THEN
           IF (skebint == 0.) skebint=deltim
@@ -236,6 +240,15 @@ module compns_stochy_mod
           nsshum=nint(shumint/deltim)                              ! shumint in seconds
           IF(nsshum<=0 .or. abs(nsshum-shumint/deltim)>tol) THEN
              WRITE(0,*) "SHUM interval is invalid",shumint
+            iret=9
+            return
+          ENDIF
+      ENDIF
+      IF (do_spp) THEN
+          IF (sppint == 0.) sppint=deltim
+          nsspp=nint(sppint/deltim)                                ! sppint in seconds
+          IF(nsspp<=0 .or. abs(nsspp-sppint/deltim)>tol) THEN
+             WRITE(0,*) "SPP interval is invalid",sppint
             iret=9
             return
           ENDIF

--- a/stochy_data_mod.F90
+++ b/stochy_data_mod.F90
@@ -433,7 +433,7 @@ module stochy_data_mod
          endif
       endif
       ones = 1.
-      call patterngenerator_init(spp_lscale(1:nspp),real(delt,kind_phys),spp_tau(1:nspp),ones(1:nspp),iseed_spp,rpattern_spp, &
+      call patterngenerator_init(spp_lscale(1:nspp),sppint,spp_tau(1:nspp),ones(1:nspp),iseed_spp,rpattern_spp, &
                                  lonf,latg,jcap,gis_stochy%ls_node,nspp,n_var_spp,0,new_lscale)
       do n=1,nspp
          if (is_rootpe()) print *, 'Initialize random pattern for SPP PERTS'

--- a/stochy_namelist_def.F90
+++ b/stochy_namelist_def.F90
@@ -12,7 +12,7 @@
       public
       integer, parameter :: max_n_var_lndp = 20 ! must match value used in GFS_typedefs
       integer, parameter :: max_n_var_spp  = 6 ! must match value used in GFS_typedefs
-      integer nssppt,nsshum,nsepbl,nsocnsppt,nsskeb,lon_s,lat_s,ntrunc
+      integer nsspp,nssppt,nsshum,nsepbl,nsocnsppt,nsskeb,lon_s,lat_s,ntrunc
 
 ! pjp stochastic phyics
       integer skeb_varspect_opt,skeb_npass
@@ -21,7 +21,7 @@
       real(kind=kind_phys) :: skeb_sigtop1,skeb_sigtop2,          &
                          sppt_sigtop1,sppt_sigtop2,shum_sigefold, &
                          skeb_vdof
-      real(kind=kind_phys) skeb_diss_smooth,epblint,ocnspptint,spptint,shumint,skebint,skebnorm
+      real(kind=kind_phys) skeb_diss_smooth,epblint,ocnspptint,sppint,spptint,shumint,skebint,skebnorm
       real(kind=kind_phys), dimension(5) :: skeb,skeb_lscale,skeb_tau
       real(kind=kind_phys), dimension(5) :: sppt,sppt_lscale,sppt_tau
       real(kind=kind_phys), dimension(5) :: shum,shum_lscale,shum_tau


### PR DESCRIPTION
This PR adds the stochastic pattern interval (sppint) option to SPP and (lndpint) to the land perturbations (LNDP).  A value of zero will update the pattern every time step.  SPP and LNDP are currently configured to run this way without the sppint/lndpint option.  Integer values greater than zero will pause pattern updates for that many seconds.  Perturbations will still be added every time step, regardless.