### PR TITLE
Clean up compiler warnings

### DIFF
--- a/cellular_automata_global.F90
+++ b/cellular_automata_global.F90
@@ -167,7 +167,7 @@ k_in=1
        else
           ! don't rely on compiler to truncate integer(8) to integer(4) on
           ! overflow, do wrap around explicitly.
-          count4 = mod(((iseed_ca+7)*mytile)*(i1+nx_full*(j1-1))+ 2147483648, 4294967296) - 2147483648
+          count4 = mod(((iseed_ca+7)*mytile)*(i1+nx_full*(j1-1))+ 2147483648_8, 4294967296_8) - 2147483648_8
        endif
        ct=1
        do nf=1,nca

--- a/cellular_automata_sgs.F90
+++ b/cellular_automata_sgs.F90
@@ -296,7 +296,7 @@ if (cold_start_ca_sgs) then
             else
                ! don't rely on compiler to truncate integer(8) to integer(4) on
                ! overflow, do wrap around explicitly.
-               count4 = mod((iseed_ca+mytile)*(i1+nx_full*(j1-1))+ 2147483648, 4294967296) - 2147483648
+               count4 = mod((iseed_ca+mytile)*(i1+nx_full*(j1-1))+ 2147483648_8, 4294967296_8) - 2147483648_8
             endif
             ct=1
             do nf=1,nca

--- a/plumes.F90
+++ b/plumes.F90
@@ -1,3 +1,6 @@
+module plumes_mod
+
+contains
 subroutine plumes(V,L,AG,a,row,col,kend)
 implicit none
 
@@ -165,3 +168,5 @@ enddo
 
 
 end subroutine plumes
+
+end module plumes_mod

--- a/spectral_transforms.F90
+++ b/spectral_transforms.F90
@@ -723,11 +723,13 @@ module spectral_transforms
       END
 
       SUBROUTINE RADBG_STOCHY (IDO,IP,L1,IDL1,CC,C1,C2,CH,CH2,WA)
-      implicit real(kind=kind_dbl_prec) (A-H)
-      implicit real(kind=kind_dbl_prec) (O-Z)
+      implicit none
+      INTEGER :: IDO,IP,L1,IDL1
       REAL(kind_dbl_prec) :: CH(IDO,L1,IP), CC(IDO,IP,L1), C1(IDO,L1,IP), C2(IDL1,IP), &
                 CH2(IDL1,IP) , WA(*)
       REAL(kind_dbl_prec), parameter :: TPI=6.28318530717959
+      REAL(kind_dbl_prec) :: ARG, DCP, DSP, AI1, AI2, AR1, AR1H, DC2, DS2, AR2, AR2H
+      INTEGER :: I,J,K,IK, IDP2, IPP2, IPPH, JC, J2, IC, L, IS, IDIJ, NBD, LC
       ARG = TPI/FLOAT(IP)
       DCP = COS(ARG)
       DSP = SIN(ARG)

--- a/spectral_transforms.F90
+++ b/spectral_transforms.F90
@@ -1476,7 +1476,6 @@ module spectral_transforms
           i2 = iindx2(i)
           if(wrk(i) .eq. 0.0) then
             write(6,*) ' la2ga: error'
-            call sleep(2)
             stop
           endif
         enddo

--- a/stochy_data_mod.F90
+++ b/stochy_data_mod.F90
@@ -485,11 +485,9 @@ module stochy_data_mod
    
    integer :: nn,nm,stochlun,n,jcapin
    integer :: l,jbasev,jbasod
-   integer :: indev,indod,indlsod,indlsev,varid1,varid2,varid3,varid4,ierr
+   integer :: indev,indod,varid1,varid2,varid3,varid4,ierr
    
    real(kind_phys),allocatable :: noise_e(:,:),noise_o(:,:)
-   include 'function_indlsod'
-   include 'function_indlsev'
    include 'netcdf.inc'
    stochlun=99
    levs=nlevs

--- a/stochy_patterngenerator.F90
+++ b/stochy_patterngenerator.F90
@@ -158,8 +158,8 @@ module stochy_patterngenerator_mod
            !count4 = iseed(np) + member_id
            ! don't rely on compiler to truncate integer(8) to integer(4) on
            ! overflow, do wrap around explicitly.
-           !count4 = mod(iseed(np) + member_id + 2147483648, 4294967296) - 2147483648
-           count4 = mod(iseed(np) + 2147483648, 4294967296) - 2147483648
+           !count4 = mod(iseed(np) + member_id + 2147483648_8, 4294967296_8) - 2147483648_8
+           count4 = mod(iseed(np) + 2147483648_8, 4294967296_8) - 2147483648_8
            print *,'using seed',count4,iseed(np)!,member_id
          endif
       endif

--- a/update_ca.F90
+++ b/update_ca.F90
@@ -289,6 +289,8 @@ subroutine update_cells_sgs(kstep,halo,dt,initialize_ca,iseed_ca,first_flag,rest
                             CA,ca_plumes,iini,ilives_in,uhigh,vhigh,dxhigh,nlives,     &
                             nfracseed,nseed,nspinup,nf,nca_plumes,ncells,mytile)
 
+use plumes_mod
+
 implicit none
 
 integer, intent(in)  :: kstep,nxc,nyc,nlon,nlat,nxch,nych,nca,isc,iec,jsc,jec,npx,npy

--- a/update_ca.F90
+++ b/update_ca.F90
@@ -395,7 +395,7 @@ if(mod(kstep,nseed)==0. .and. (kstep >= initialize_ca .or. start_from_restart))t
             count_trunc = iscale*(count/iscale)
             count4 = count - count_trunc + mytile *( i1+nx_full*(j1-1)) ! no need to multply by 7 since time will be different in sgs
          else
-            count4 = mod((iseed_ca*nf+mytile)*(i1+nx_full*(j1-1))+ 2147483648, 4294967296) - 2147483648
+            count4 = mod((iseed_ca*nf+mytile)*(i1+nx_full*(j1-1))+ 2147483648_8, 4294967296_8) - 2147483648_8
          endif
          noise_b(i,j)=real(random_01_CB(kstep,count4),kind=8)
       enddo
@@ -706,7 +706,7 @@ if(mod(kstep,nseed) == 0)then
             count_trunc = iscale*(count/iscale)
             count4 = count - count_trunc + mytile *( i1+nx_full*(j1-1)) ! no need to multply by 7 since time will be different in sgs
          else
-            count4 = mod(iseed_ca*nf+(7*mytile)*(i1+nx_full*(j1-1))+ 2147483648, 4294967296) - 2147483648
+            count4 = mod(iseed_ca*nf+(7*mytile)*(i1+nx_full*(j1-1))+ 2147483648_8, 4294967296_8) - 2147483648_8
          endif
          noise_b(i,j)=real(random_01_CB(kstep,count4),kind=8)
       enddo


### PR DESCRIPTION
This PR cleans up compiler warnings when Intel compiler is used without a compiler flag that suppresses all warnings.

fixes:  #73 