### PR TITLE
Add if(allocated) checks to avoid segfaults

### DIFF
--- a/stochastic_physics.F90
+++ b/stochastic_physics.F90
@@ -540,7 +540,7 @@ if (pert_epbl .OR. do_ocnsppt) then
       call get_random_pattern_scalar(rpattern_ocnsppt, nocnsppt, gis_stochy_ocn, tmp_wts)
       sppt_wts = 2.0 / (1.0 + exp(-1 * tmp_wts))
    else
-      sppt_wts = 1.0
+      if (ALLOCATED(sppt_wts) ) sppt_wts = 1.0
    endif
    deallocate(tmp_wts)
 else
@@ -552,7 +552,7 @@ endif
 if (do_ocnskeb) then
    call get_random_pattern_scalar(rpattern_ocnskeb, nocnskeb, gis_stochy_ocn_skeb, skeb_wts, normalize=.true.)
 else
-   skeb_wts(:,:) = 1.0
+   if (ALLOCATED(skeb_wts) ) skeb_wts(:,:) = 1.0
 endif
 
 end subroutine run_stochastic_physics_ocn

--- a/stochastic_physics.F90
+++ b/stochastic_physics.F90
@@ -525,34 +525,21 @@ implicit none
 real(kind_dbl_prec), intent(inout) :: sppt_wts(:,:), t_rp1(:,:), t_rp2(:,:), skeb_wts(:,:)
 real(kind_dbl_prec), allocatable :: tmp_wts(:,:)
 
-if (pert_epbl .OR. do_ocnsppt) then
-   allocate(tmp_wts(gis_stochy_ocn%nx, gis_stochy_ocn%ny))
-   if (pert_epbl) then
-      call get_random_pattern_scalar(rpattern_epbl1, nepbl, gis_stochy_ocn, tmp_wts)
-      t_rp1(:,:) = 2.0 / (1.0 + exp(-1 * tmp_wts))
-      call get_random_pattern_scalar(rpattern_epbl2, nepbl, gis_stochy_ocn, tmp_wts)
-      t_rp2(:,:) = 2.0 / (1.0 + exp(-1 * tmp_wts))
-   else
-      t_rp1(:,:) = 1.0
-      t_rp2(:,:) = 1.0
-   endif
-   if (do_ocnsppt) then
-      call get_random_pattern_scalar(rpattern_ocnsppt, nocnsppt, gis_stochy_ocn, tmp_wts)
-      sppt_wts = 2.0 / (1.0 + exp(-1 * tmp_wts))
-   else
-      if (ALLOCATED(sppt_wts) ) sppt_wts = 1.0
-   endif
-   deallocate(tmp_wts)
-else
-   sppt_wts(:,:) = 1.0
-   t_rp1(:,:) = 1.0
-   t_rp2(:,:) = 1.0
+allocate(tmp_wts(gis_stochy_ocn%nx, gis_stochy_ocn%ny))
+if (pert_epbl) then
+  call get_random_pattern_scalar(rpattern_epbl1, nepbl, gis_stochy_ocn, tmp_wts)
+  t_rp1(:,:) = 2.0 / (1.0 + exp(-1 * tmp_wts))
+  call get_random_pattern_scalar(rpattern_epbl2, nepbl, gis_stochy_ocn, tmp_wts)
+  t_rp2(:,:) = 2.0 / (1.0 + exp(-1 * tmp_wts))
 endif
+if (do_ocnsppt) then
+  call get_random_pattern_scalar(rpattern_ocnsppt, nocnsppt, gis_stochy_ocn, tmp_wts)
+  sppt_wts = 2.0 / (1.0 + exp(-1 * tmp_wts))
+endif
+deallocate(tmp_wts)
 
 if (do_ocnskeb) then
    call get_random_pattern_scalar(rpattern_ocnskeb, nocnskeb, gis_stochy_ocn_skeb, skeb_wts, normalize=.true.)
-else
-   if (ALLOCATED(skeb_wts) ) skeb_wts(:,:) = 1.0
 endif
 
 end subroutine run_stochastic_physics_ocn


### PR DESCRIPTION
Code currently fills sppt_wts and skeb_wts whether or not associated with a target or allocated in MOM6. This leads to a segmentation fault in a UFS regression test (see https://github.com/ufs-community/ufs-weather-model/issues/2711)

Protect by checking whether allocated first