### PR TITLE
Remove separate iseed_ca <= 0 logic in update_ca.F90

### DIFF
--- a/update_ca.F90
+++ b/update_ca.F90
@@ -392,13 +392,7 @@ if(mod(kstep,nseed)==0. .and. (kstep >= initialize_ca .or. start_from_restart))t
       j1=j+(jsc-1)*ncells
       do i=1,nxc
          i1=i+(isc-1)*ncells
-         if (iseed_ca <= 0) then
-            !call system_clock(count, count_rate, count_max)
-            count_trunc = iscale*(count/iscale)
-            count4 = count - count_trunc + mytile *( i1+nx_full*(j1-1)) ! no need to multply by 7 since time will be different in sgs
-         else
-            count4 = int(mod(int((iseed_ca*nf+mytile)*(i1+nx_full*(j1-1)), 8) + 2147483648_8, 4294967296_8) - 2147483648_8)
-         endif
+         count4 = int(mod(int((iseed_ca*nf+mytile)*(i1+nx_full*(j1-1)), 8) + 2147483648_8, 4294967296_8) - 2147483648_8)
          noise_b(i,j)=real(random_01_CB(kstep,count4),kind=8)
       enddo
    enddo
@@ -703,13 +697,7 @@ if(mod(kstep,nseed) == 0)then
       j1=j+(jsc-1)*ncells
       do i=1,nxc
          i1=i+(isc-1)*ncells
-         if (iseed_ca <= 0) then
-            !call system_clock(count, count_rate, count_max)
-            count_trunc = iscale*(count/iscale)
-            count4 = count - count_trunc + mytile *( i1+nx_full*(j1-1)) ! no need to multply by 7 since time will be different in sgs
-         else
-            count4 = int(mod(int(iseed_ca*nf+(7*mytile)*(i1+nx_full*(j1-1)), 8) + 2147483648_8, 4294967296_8) - 2147483648_8)
-         endif
+         count4 = int(mod(int(iseed_ca*nf+(7*mytile)*(i1+nx_full*(j1-1)), 8) + 2147483648_8, 4294967296_8) - 2147483648_8)
          noise_b(i,j)=real(random_01_CB(kstep,count4),kind=8)
       enddo
    enddo


### PR DESCRIPTION
In compiling UFS, there is a warning that:
```
/work/noaa/nems/nszapiro/tasks/gefs_ort/ufs-weather-model/stochastic_physics/update_ca.F90:397:47:
  397 |             count_trunc = iscale*(count/iscale)
      |                                               ^
Warning: 'count' may be used uninitialized [-Wmaybe-uninitialized]
```
It seems that initializing count (if iseed_ca <= 0) via system_clock was removed in https://github.com/NOAA-PSL/stochastic_physics/pull/47 .

I'm not familiar with the internals/intent here. One option is to remove the separate conditions (as here). Another is to initialize count more appropriately.

fyi, any change here is expected to be bit-for-bit in UFS regression tests as iseed_ca>0.